### PR TITLE
fix issue with volume of litres products

### DIFF
--- a/ahl_targets/pipeline/hfss.py
+++ b/ahl_targets/pipeline/hfss.py
@@ -110,7 +110,7 @@ def kcal_per_100g_drinks(df):
 
 def nut_per_100g_drinks(df, col):
     """Returns series with macro per 100 g"""
-    return (100 * (df[col] / df["volume_up"])) * df["sg"]
+    return 100 * (df[col] / (df["volume_up"] * df["sg"]))
 
 
 def drink_per_100g(prod_lt_nut):


### PR DESCRIPTION

---

# Description

I have investigated the reasons behind the missing NPM scores and found and fixed them where possible:

- there was a problem with the calculation of kcal and nutrients per 100g for litres product, which has been fixed
- I removed the threshold of 900 kcal/g for litre products because a large number where dropped because just above the threshold, but given that the specific gravities are not exact values but they are based on category average, I am not confident about excluding them
- I have updated the specific gravity file as the conversion factor for aerosol creams gave implausible values (changed to default 1) - **if you have the specific gravity file stored locally, please update it by downloading from S3**
- after this about 0.8% of the sample remains missing and this is due to the exclusion criteria on kcal per 100g being less than 900 for foods: the majority of these are products for which we have imputed the volume. Unless we are willing to revisit the volume imputation, I would suggest leaving them out

Fixes #14

# Instructions for Reviewer

In order to test the code in this PR you need to check the script `ahl_targets/pipeline/hfss.py `


# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [x] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
