### PR TITLE
split out lidl and aldi

### DIFF
--- a/ahl_targets/pipeline/stores_transformation.py
+++ b/ahl_targets/pipeline/stores_transformation.py
@@ -1,37 +1,11 @@
-import re
 import numpy as np
-
-
-def aldi(store_levels):
-    """Splits out Aldi from level 4 to 3"""
-    aldi_stores = np.where(
-        store_levels["itemisation_level_4"] == "Aldi",
-        "Aldi",
-        store_levels["itemisation_level_3"],
-    )
-    store_levels["itemisation_level_3"] = aldi_stores
-    return store_levels
-
-
-def lidl(store_levels):
-    """Splits out Lidl from level 4 to 3"""
-    lidl_stores = np.where(
-        store_levels["itemisation_level_4"] == "Lidl",
-        "Lidl",
-        store_levels["itemisation_level_3"],
-    )
-    store_levels["itemisation_level_3"] = lidl_stores
-    return store_levels
 
 
 def taxonomy(store_code, store_line):
     """Returns merged dataset with store types"""
-    return (
-        store_code.merge(store_line, on=["itemisation_id", "itemisation_line_id"])
-        .query("itemisation_id == 1")
-        .pipe(aldi)
-        .pipe(lidl)
-    )
+    return store_code.merge(
+        store_line, on=["itemisation_id", "itemisation_line_id"]
+    ).query("itemisation_id == 1")
 
 
 def online(dat):


### PR DESCRIPTION
---

# Description

Added functions to `pipeline/stores_transformation.py` to ensure that Aldi and Lidl are always split out in level 3 and also added a function to generate custom taxonomy as requested by AHL

Fixes #34 

# Instructions for Reviewer

In order to test the code in this PR you need to check `pipeline/stores_transformation.py`

# Checklist:

- [x] I have refactored my code out from `notebooks/`
- [x] I have checked the code runs
- [x] I have tested the code
- [x] I have run `pre-commit` and addressed any issues not automatically fixed
- [x] I have merged any new changes from `dev`
- [x] I have documented the code
  - [x] Major functions have docstrings
  - [ ] Appropriate information has been added to `README`s
- [x] I have explained this PR above
- [x] I have requested a code review
